### PR TITLE
Added missing comma to default config file

### DIFF
--- a/packages/core/src/cli/templates/config.js
+++ b/packages/core/src/cli/templates/config.js
@@ -28,7 +28,7 @@ module.exports = {
   // and needs to provide functions for setup and rendering. For details see the adapters docs.
   adapters: {
     html: '@uiengine/adapter-html'
-  }
+  },
 
   // Here you can configure the template that the variant preview gets embeded in.
   template: 'uiengine.html',


### PR DESCRIPTION
I've generated a new project according to the readme, but the `uiengine.config.js` misses a comma.

```
$ uiengine component button
🚨  creating the component button failed!

Error: Could not read UIengine configuration:

Unexpected identifier
    at Object.read (/.../node_modules/@uiengine/core/lib/configuration.js:63:11)
    at <anonymous>
```