### PR TITLE
fix debug for unparsable state.config

### DIFF
--- a/packages/util/src/debug.js
+++ b/packages/util/src/debug.js
@@ -1,7 +1,7 @@
 const { yellow } = require('chalk')
 
 const _debug = (level, state, label, ...additional) => {
-  const { debug } = state.config
+  const { debug } = state.config || {}
   if (!debug || level > debug) return
 
   const [, timingLabel, timingEvent] = label.match(/(.*):(start|end)$/) || []


### PR DESCRIPTION
Cannot destructure property `debug` of 'undefined' or 'null'.

occurred when state.config == undefined