### PR TITLE
Feature/multithemes

### DIFF
--- a/docs/design-tokens.md
+++ b/docs/design-tokens.md
@@ -46,7 +46,7 @@ These attributes are optional:
 - `variable`: Variable name
 - `reference`: The name of the referenced token
 - `description`
-- `theme`: Restricts display to only the given theme id. Can be used for categories and tokens.
+- `theme`: Restricts display to only the given theme id(s). Can be used for categories and tokens. Use an array to specify multiple themes.
 
 ### Types
 

--- a/docs/variant.md
+++ b/docs/variant.md
@@ -48,6 +48,7 @@ module.exports = {
       title: "Primary button",
       description: "Use this for calls to action",
       label: "B1-2",
+      theme: ["plain", "funky"],
       // the primary button provides its own context,
       // hence it does not inherit the general context
       context: {
@@ -67,7 +68,7 @@ Attributes:
   If the veriant does not specify an own context it will be inherited from the general context specified on the component level.
 - `title` and `description` get displayed in the documentation.
 - `label` is an individual marker that can be used as a reference in mockups or wireframes to reference variants.
-- `theme`: Restricts display to only the given theme id.
+- `theme`: Restricts display to only the given theme id(s). Use an array to specify multiple themes.
 
 You can also provide a short version of the `variants` list like this:
 

--- a/packages/ui/src/vue/components/MainComponent.vue
+++ b/packages/ui/src/vue/components/MainComponent.vue
@@ -335,7 +335,7 @@ export default {
     },
 
     displayVariant (variant) {
-      return !!(!variant.theme || this.currentTheme.id.includes(variant.theme))
+      return !!(!variant.theme || variant.theme.includes(this.currentTheme.id))
     },
 
     tabId (section) {

--- a/packages/ui/src/vue/components/MainComponent.vue
+++ b/packages/ui/src/vue/components/MainComponent.vue
@@ -335,7 +335,7 @@ export default {
     },
 
     displayVariant (variant) {
-      return !!(!variant.theme || variant.theme === this.currentTheme.id)
+      return !!(!variant.theme || this.currentTheme.id.includes(variant.theme))
     },
 
     tabId (section) {

--- a/test/project/src/elements/label/component.config.js
+++ b/test/project/src/elements/label/component.config.js
@@ -53,7 +53,7 @@ module.exports = {
       title: 'Label (Pug)',
       label: 'A1.4',
       tags: ['Pug'],
-      theme: 'plain'
+      theme: ['plain']
     },
     {
       file: 'label.jsx',


### PR DESCRIPTION
The option to restrict variant display to a given theme id was added in 2.1.0 following an issue from one of our devs. We are currently working on a DS with 3 themes: this PR is a progressive enhancement on the 2.1.0 release (the old syntax still works) allowing to address more than one theme in the `theme` option.
Semantic suggests the property should be called _themes_ but this would break compatibility or add two config options achieving the same goal.

Documentation is updated. Let me know if the commits should be squashed or if there are any issues with coding style (changes are minimal).

This project is really well done and it's a pleasure to contribute to it. Awesome job Dennis, it's a great tool!

Best,
Matteo