### PR TITLE
Add CSS preprocessors to syntax highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "eslint-plugin-promise": "4.0.1",
     "eslint-plugin-standard": "4.0.0",
     "fs-extra": "7.0.1",
-    "handlebars": "4.1.0",
+    "handlebars": "4.1.1",
     "highlight.js": "^9.15.6",
     "husky": "1.3.1",
     "lerna": "3.13.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "eslint-plugin-standard": "4.0.0",
     "fs-extra": "7.0.1",
     "handlebars": "4.1.0",
+    "highlight.js": "^9.15.6",
     "husky": "1.3.1",
     "lerna": "3.13.0",
     "lighthouse-ci": "1.4.1",

--- a/packages/ui/src/shared/highlight.js
+++ b/packages/ui/src/shared/highlight.js
@@ -1,6 +1,6 @@
 const hljs = require('highlight.js/lib/highlight')
 
-const LANGUAGES = ['bash', 'css', 'scss', 'javascript', 'handlebars', 'json', 'markdown', 'nginx', 'xml']
+const LANGUAGES = ['bash', 'css', 'scss', 'less', 'stylus', 'javascript', 'handlebars', 'json', 'markdown', 'nginx', 'xml']
 
 LANGUAGES.forEach(name => {
   const lang = require(`highlight.js/lib/languages/${name}`)

--- a/packages/ui/src/shared/highlight.js
+++ b/packages/ui/src/shared/highlight.js
@@ -1,6 +1,6 @@
 const hljs = require('highlight.js/lib/highlight')
 
-const LANGUAGES = ['bash', 'css', 'javascript', 'handlebars', 'json', 'markdown', 'nginx', 'xml']
+const LANGUAGES = ['bash', 'css', 'scss', 'javascript', 'handlebars', 'json', 'markdown', 'nginx', 'xml']
 
 LANGUAGES.forEach(name => {
   const lang = require(`highlight.js/lib/languages/${name}`)


### PR DESCRIPTION
This PR references the latest comment in issue #36 .
A minor change to `package.json` can be dropped to avoid merge issues.

Once again, thanks for the awesome work in providing uiengine. We look forward to more solid contributions the more we hit edge use cases.