### PR TITLE
🐛UI: Fix the in-page navigation overlapping issue on medium viewports

### DIFF
--- a/packages/ui/src/vue/components/App.vue
+++ b/packages/ui/src/vue/components/App.vue
@@ -90,9 +90,6 @@ export default {
     padding-top var(--uie-space-xl)
     padding-bottom var(--uie-space-xl)
 
-  .in-page-nav
-    display none
-
 @media $mq-l_and_up
   .layout
     --topbar-height 4rem
@@ -124,13 +121,6 @@ export default {
     margin-left var(--navigation-width)
     padding-top var(--uie-space-xxl)
     padding-bottom var(--uie-space-xxl)
-
-  .in-page-nav
-    display block
-    position fixed
-    top calc(var(--topbar-height) + var(--uie-space-xxl))
-    right var(--uie-space-xxl)
-    width 140px
 
   .footer
     margin-left var(--navigation-width)
@@ -169,6 +159,16 @@ export default {
 .main
   @media $mq-xl_and_up
     padding-right calc(var(--uie-space-xxl) * 3 + 140px)
+
+.in-page-nav
+  margin-top var(--uie-space-xxl)
+  @media $mq-xl_and_up
+    display block
+    position fixed
+    top calc(var(--topbar-height) + var(--uie-space-xxl))
+    right var(--uie-space-xxl)
+    width 140px
+    margin-top 0
 
 @media print
   .topbar,

--- a/packages/ui/src/vue/components/MainComponent.vue
+++ b/packages/ui/src/vue/components/MainComponent.vue
@@ -380,6 +380,9 @@ export default {
   margin-bottom var(--uie-space-xxxl)
   border-width 1px
   @media $mq-l_and_up
+    margin-left calc(var(--uie-space-xl) * -1)
+    margin-right calc(var(--uie-space-xl) * -1)
+  @media $mq-xl_and_up
     margin-left calc(var(--uie-space-xxl) * -1)
     margin-right calc(var(--uie-space-xxl) * -1)
 

--- a/packages/ui/src/vue/components/MainTemplate.vue
+++ b/packages/ui/src/vue/components/MainTemplate.vue
@@ -322,6 +322,9 @@ export default {
     margin-bottom var(--uie-space-xxxl)
     border-width 1px
     @media $mq-l_and_up
+      margin-left calc(var(--uie-space-xl) * -1)
+      margin-right calc(var(--uie-space-xl) * -1)
+    @media $mq-xl_and_up
       margin-left calc(var(--uie-space-xxl) * -1)
       margin-right calc(var(--uie-space-xxl) * -1)
 </style>

--- a/packages/ui/src/vue/components/MainTokens.vue
+++ b/packages/ui/src/vue/components/MainTokens.vue
@@ -85,6 +85,9 @@ export default {
   margin-bottom var(--uie-space-xxxl)
   border-width 1px
   @media $mq-l_and_up
+    margin-left calc(var(--uie-space-xl) * -1)
+    margin-right calc(var(--uie-space-xl) * -1)
+  @media $mq-xl_and_up
     margin-left calc(var(--uie-space-xxl) * -1)
     margin-right calc(var(--uie-space-xxl) * -1)
 


### PR DESCRIPTION
- Update the in-page navigation to be fixed only from xl_and_up 
viewports. On smaller viewport will sit underneath the contentsection 
list items
- Fix a horizontal overflowing issue on medium viewports because of 
wider horizontal rules