### PR TITLE
🔀 fix concurrency issue when using plugin

### DIFF
--- a/packages/util/src/file.js
+++ b/packages/util/src/file.js
@@ -48,7 +48,7 @@ async function write (filePath, content) {
 async function copy (src, dst) {
   const dir = dirname(dst)
   fs.mkdirsSync(dir)
-  await fs.copy(src, dst, { dereference: true })
+  fs.copySync(src, dst, { dereference: true })
 }
 
 module.exports = {


### PR DESCRIPTION
After updating the uiengine in our project, we ran into a concurrency issue during the build process when using a plugin. The output:

```
Error: EEXIST: file already exists, mkdir '[PROJECT ROOT]/dist'
    at Object.setup ([PROJECT ROOT]/node_modules/@uiengine/core/node_modules/@uiengine/ui/src/index.js:71:11)
```

The issue can be fixed for us by using the the synchronous copy function from fs-extra in file.js.

@naltatis 👀